### PR TITLE
Add basic room join and Firestore subscription

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -9,6 +9,7 @@
 <div id="app">
   <header>
     <div>Room: <span id="room-code">—</span> <span>(player: <span id="player-id">—</span>)</span></div>
+    <button id="open-join">Join or Create</button>
     <button id="deal" disabled>Deal</button>
     <select id="variant" disabled>
       <option>Hold'em</option>
@@ -119,6 +120,22 @@
       </div>
       <div id="debug-log"></div>
     </aside>
+  </div>
+</div>
+<div id="join-overlay" class="hidden">
+  <div class="join-modal">
+    <h2>Join or Create Room</h2>
+    <label>Display Name
+      <input id="displayName" type="text" maxlength="20" />
+    </label>
+    <label>Room Code
+      <input id="roomCode" type="text" maxlength="8" />
+    </label>
+    <div id="join-error" class="error"></div>
+    <div class="buttons">
+      <button id="create-room">Create Room</button>
+      <button id="join-room">Join Room</button>
+    </div>
   </div>
 </div>
 <script type="module" src="./app.js"></script>

--- a/public/app.js
+++ b/public/app.js
@@ -8,6 +8,10 @@ import {
   signInAnonymously,
   onAuthStateChanged
 } from "https://www.gstatic.com/firebasejs/11.0.1/firebase-auth.js";
+import {
+  getFirestore, doc, getDoc, setDoc, runTransaction, onSnapshot,
+  serverTimestamp, updateDoc
+} from "https://www.gstatic.com/firebasejs/11.0.1/firebase-firestore.js";
 
 let roomCode = null;
 
@@ -33,6 +37,7 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
+const db = getFirestore(app);
 
 await setPersistence(auth, browserSessionPersistence);
 await signInAnonymously(auth);
@@ -66,3 +71,200 @@ document.getElementById('preview-btn').addEventListener('click', () => {
   container.innerHTML = '';
   container.appendChild(img);
 });
+
+function normalizeRoomCode(raw) {
+  const s = (raw || '').toUpperCase().replace(/[^A-Z0-9]/g, '');
+  return s.slice(0, 8);
+}
+
+function genRoomCode(len = 6) {
+  const alphabet = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+  let out = '';
+  for (let i = 0; i < len; i++) out += alphabet[Math.floor(Math.random() * alphabet.length)];
+  return out;
+}
+
+const joinOverlay = document.getElementById('join-overlay');
+const openJoinBtn = document.getElementById('open-join');
+const displayNameInput = document.getElementById('displayName');
+const roomCodeInput = document.getElementById('roomCode');
+const joinError = document.getElementById('join-error');
+
+function openJoin() {
+  joinOverlay.classList.remove('hidden');
+  joinError.textContent = '';
+  displayNameInput.classList.remove('invalid');
+  roomCodeInput.classList.remove('invalid');
+  setTimeout(() => displayNameInput.focus(), 0);
+  debug.log('ui.join.open', {});
+}
+
+function closeJoin() {
+  joinOverlay.classList.add('hidden');
+}
+
+if (openJoinBtn) {
+  openJoinBtn.addEventListener('click', openJoin);
+}
+
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'Escape') {
+    closeJoin();
+  }
+});
+
+document.getElementById('create-room').addEventListener('click', () => submitJoin('create'));
+document.getElementById('join-room').addEventListener('click', () => submitJoin('join'));
+
+let roomUnsub = null;
+
+async function submitJoin(mode) {
+  const displayName = displayNameInput.value.trim();
+  let code = normalizeRoomCode(roomCodeInput.value);
+
+  displayNameInput.classList.remove('invalid');
+  roomCodeInput.classList.remove('invalid');
+
+  if (displayName.length < 2 || displayName.length > 20) {
+    joinError.textContent = 'Name must be 2–20 characters.';
+    displayNameInput.classList.add('invalid');
+    debug.log('room.join.error', { code, reason: 'VALIDATION' });
+    return;
+  }
+
+  if (mode === 'create' && !code) {
+    code = genRoomCode();
+  }
+
+  if (!code || code.length < 4) {
+    joinError.textContent = 'Room code must be 4–8 characters.';
+    roomCodeInput.classList.add('invalid');
+    debug.log('room.join.error', { code, reason: 'VALIDATION' });
+    return;
+  }
+
+  joinError.textContent = '';
+  debug.log('ui.join.submit', { mode, code, displayName });
+
+  const uid = auth.currentUser?.uid;
+  try {
+    let created = false;
+    const seat = await runTransaction(db, async (tx) => {
+      const roomRef = doc(db, 'rooms', code);
+      const snap = await tx.get(roomRef);
+      let data;
+      if (!snap.exists()) {
+        data = {
+          code,
+          active: true,
+          createdAt: serverTimestamp(),
+          state: 'idle',
+          variant: null,
+          dealerSeat: null,
+          seats: [null, null, null, null, null, null, null, null, null],
+          players: {}
+        };
+        tx.set(roomRef, data);
+        created = true;
+      } else {
+        data = snap.data();
+      }
+
+      data.players = data.players || {};
+      data.seats = data.seats || [null, null, null, null, null, null, null, null, null];
+
+      let player = data.players[uid];
+      if (!player) {
+        player = {
+          displayName,
+          active: true,
+          seat: null,
+          joinedAt: serverTimestamp(),
+          lastSeen: serverTimestamp()
+        };
+      } else {
+        player.displayName = displayName;
+        player.active = true;
+        player.lastSeen = serverTimestamp();
+      }
+
+      if (player.seat == null) {
+        const seatIndex = data.seats.findIndex((s) => s == null);
+        if (seatIndex === -1) {
+          throw new Error('ROOM_FULL');
+        }
+        player.seat = seatIndex;
+        data.seats[seatIndex] = uid;
+      } else {
+        const seatIndex = player.seat;
+        if (data.seats[seatIndex] !== uid) {
+          data.seats[seatIndex] = uid;
+        }
+      }
+
+      data.players[uid] = player;
+      tx.set(roomRef, { code, players: data.players, seats: data.seats }, { merge: true });
+      return player.seat;
+    });
+
+    roomCode = code;
+    window.APP = window.APP || {};
+    window.APP.roomCode = code;
+    document.getElementById('room-code').textContent = code;
+    document.getElementById('debug-room').textContent = code;
+    debug.log('room.join.success', { code, seat });
+    if (created) {
+      debug.log('room.create.success', { code });
+    }
+    closeJoin();
+
+    const roomRef = doc(db, 'rooms', code);
+    await updateDoc(roomRef, {
+      [`players.${uid}.lastSeen`]: serverTimestamp(),
+      [`players.${uid}.active`]: true
+    });
+
+    if (roomUnsub) roomUnsub();
+    roomUnsub = onSnapshot(roomRef, (snap) => {
+      const data = snap.data();
+      renderRoom(data);
+      const playersCount = data.players ? Object.keys(data.players).length : 0;
+      const seatedCount = data.seats ? data.seats.filter(Boolean).length : 0;
+      debug.log('room.snapshot', { players: playersCount, seated: seatedCount });
+    });
+  } catch (err) {
+    if (err.message === 'ROOM_FULL') {
+      joinError.textContent = 'Room is full.';
+      debug.log('room.join.error', { code, reason: 'ROOM_FULL' });
+    } else {
+      joinError.textContent = 'Failed to join room.';
+      debug.log('room.join.error', { code, reason: 'UNKNOWN' });
+    }
+  }
+}
+
+function renderRoom(data) {
+  for (let i = 0; i < 9; i++) {
+    const seatEl = document.querySelector(`.seat-${i}`);
+    if (!seatEl) continue;
+    const nameEl = seatEl.querySelector('.name');
+    const stackEl = seatEl.querySelector('.stack');
+    const uid = data.seats ? data.seats[i] : null;
+    if (uid) {
+      nameEl.textContent = data.players?.[uid]?.displayName || 'Player';
+      let statusEl = seatEl.querySelector('.status');
+      if (!statusEl) {
+        statusEl = document.createElement('span');
+        statusEl.className = 'status';
+        nameEl.after(statusEl);
+      }
+      statusEl.textContent = 'idle';
+      stackEl.textContent = '$—';
+    } else {
+      nameEl.textContent = `Seat ${i + 1} (empty)`;
+      const statusEl = seatEl.querySelector('.status');
+      if (statusEl) statusEl.remove();
+      stackEl.textContent = '$—';
+    }
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
 <div id="app">
   <header>
     <div>Room: <span id="room-code">—</span> <span>(player: <span id="player-id">—</span>)</span></div>
+    <button id="open-join">Join or Create</button>
     <button id="deal" disabled>Deal</button>
     <select id="variant" disabled>
       <option>Hold'em</option>
@@ -119,6 +120,22 @@
       </div>
       <div id="debug-log"></div>
     </aside>
+  </div>
+</div>
+<div id="join-overlay" class="hidden">
+  <div class="join-modal">
+    <h2>Join or Create Room</h2>
+    <label>Display Name
+      <input id="displayName" type="text" maxlength="20" />
+    </label>
+    <label>Room Code
+      <input id="roomCode" type="text" maxlength="8" />
+    </label>
+    <div id="join-error" class="error"></div>
+    <div class="buttons">
+      <button id="create-room">Create Room</button>
+      <button id="join-room">Join Room</button>
+    </div>
   </div>
 </div>
 <script type="module" src="./app.js"></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -140,3 +140,70 @@ header {
   line-height: 1.4;
   white-space: pre-wrap;
 }
+
+.hidden {
+  display: none;
+}
+
+#join-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0,0,0,0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+#join-overlay .join-modal {
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 260px;
+}
+
+#join-overlay label {
+  display: flex;
+  flex-direction: column;
+  font-size: 14px;
+  gap: 4px;
+}
+
+#join-overlay input {
+  padding: 6px;
+  font-size: 14px;
+}
+
+#join-overlay .buttons {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+#join-error {
+  color: #b00;
+  font-size: 13px;
+  min-height: 1em;
+}
+
+input.invalid {
+  border: 2px solid #b00;
+}
+
+#join-error:empty {
+  display: none;
+}
+
+.seat .status {
+  display: block;
+  font-size: 12px;
+  color: #555;
+}


### PR DESCRIPTION
## Summary
- Add "Join or Create" overlay to player and admin pages
- Style join overlay and validation hints
- Implement Firestore-powered join/create flow with seat assignment and room snapshot rendering

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c22fa5e1f4832ea1e4518a5d3fbb88