### PR TITLE
feat: gate deal control to dealer and persist variant

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -45,10 +45,20 @@ header {
 .seat .badges {
   margin-top: 4px;
   height: 14px;
+  display: flex;
+  justify-content: center;
+  gap: 2px;
 }
 
 .dealer-btn, .sb-badge, .bb-badge {
   display: none;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: #fff;
+  color: #000;
+  font-size: 10px;
+  line-height: 14px;
 }
 
 .seat-0 { top: 90%; left: 50%; }
@@ -106,6 +116,11 @@ header {
 .action-bar button:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+button:disabled,
+select:disabled {
+  pointer-events: auto;
 }
 
 #debug-panel {


### PR DESCRIPTION
## Summary
- compute earliest joiner as dealer and show D badge on their seat
- gate Deal button & Variant selector to dealer, persist variant selection
- add UI-only 3s deal lock and polish disabled tooltips/badges

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2334990d4832eba9e2fb3b2f6c9b3