### PR TITLE
Implement Firestore deal lock

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -121,6 +121,13 @@ header {
 button:disabled,
 select:disabled {
   pointer-events: auto;
+  cursor: not-allowed;
+}
+
+.lock-info {
+  font-size: 12px;
+  color: #555;
+  margin-left: 8px;
 }
 
 #debug-panel {


### PR DESCRIPTION
## Summary
- add Firestore-backed deal lock with expiry and cleanup
- handle dealLocked state in UI gating and rendering
- polish disabled control styles

## Testing
- ⚠️ `npm test` (fails: package.json missing)


------
https://chatgpt.com/codex/tasks/task_e_68c234e5d71c832ebad9b0d2fab3b060