### PR TITLE
Add street advancement and board rendering

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -120,6 +120,7 @@ header {
 
 button:disabled,
 select:disabled {
+  opacity: 0.6;
   pointer-events: auto;
   cursor: not-allowed;
 }


### PR DESCRIPTION
## Summary
- Add dealer-only **Next Street** button to reveal flop, turn, and river via deterministic deck shuffling
- Render community cards from stored board indices and log board render passes
- Disable buttons with clearer styling and include hand status in gating

## Testing
- `node --check public/app.js && echo "Syntax OK"`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2388a5838832eb1a8f75d032fc02e