### PR TITLE
feat: implement per-street turn order and action gating

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -118,6 +118,27 @@ header {
   cursor: not-allowed;
 }
 
+.seat.turn {
+  animation: turnPulse 1s infinite;
+  box-shadow: 0 0 10px 2px rgba(255,255,0,0.9);
+  border-radius: 8px;
+}
+
+#my-board.my-turn {
+  animation: turnPulse 1s infinite;
+  box-shadow: 0 0 10px 2px rgba(255,255,0,0.9);
+  border-radius: 8px;
+}
+
+@keyframes turnPulse {
+  0%, 100% {
+    box-shadow: 0 0 10px 2px rgba(255,255,0,0.9);
+  }
+  50% {
+    box-shadow: 0 0 10px 4px rgba(255,165,0,0.9);
+  }
+}
+
 button:disabled,
 select:disabled {
   opacity: 0.6;


### PR DESCRIPTION
## Summary
- compute per-street acting order and track turn state
- gate action buttons to the active player with seat highlights
- record check intents and advance turn via room transaction

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c23b1111ec832eb64bc73c8defbf93