### PR TITLE
Auto-assign room display names per room

### DIFF
--- a/public/debug.js
+++ b/public/debug.js
@@ -14,7 +14,7 @@ export class Debug {
 
     this.filterEl = document.getElementById('debug-filter');
     const stored = localStorage.getItem('debug.filter.groups');
-    this.enabledGroups = new Set(stored ? JSON.parse(stored) : ['ui','hand','betting','street','settle','presence','wallet']);
+    this.enabledGroups = new Set(stored ? JSON.parse(stored) : ['ui','hand','betting','street','settle','presence','wallet','name']);
     if (this.filterEl) {
       this.filterEl.querySelectorAll('input[type="checkbox"]').forEach(cb => {
         const g = cb.dataset.group;

--- a/public/index.html
+++ b/public/index.html
@@ -8,11 +8,17 @@
 <body>
   <header class="lobby-header">
     <h1>Lobby</h1>
+    <span id="my-name"></span>
     <div id="wallet-badge">$
       <span id="wallet-balance">0</span>
     </div>
   </header>
   <main id="rooms-grid" class="rooms-grid"></main>
+  <script>
+    const n = sessionStorage.getItem('playerName');
+    const el = document.getElementById('my-name');
+    if (n && el) el.textContent = n;
+  </script>
   <script type="module" src="/lobby.js"></script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -20,7 +20,7 @@ header .left{ display:flex; align-items:center; gap:8px; }
 .seat .seat-inner{ background:rgba(0,0,0,.25); border-radius:12px; padding:8px; text-align:center; }
 .seat .badges{ height:18px; }
 .seat .badges span{ margin-right:4px; padding:2px 4px; border-radius:4px; background:#1b2130; border:1px solid rgba(255,255,255,.2); font-size:10px; }
-.seat .name{ font-weight:600; margin-top:2px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.seat .name{ font-weight:600; margin-top:2px; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:120px; }
 .seat .stack{ font-size:12px; color:#cfd5dd; }
 .seat.me{ outline:2px solid var(--gold); box-shadow:0 0 12px rgba(255,215,0,.6); }
 .seat.turn{ box-shadow:0 0 0 2px #fff, 0 0 20px rgba(255,255,255,.5); }


### PR DESCRIPTION
## Summary
- Assign PlayerN display names per room via Firestore transaction
- Persist and display names across table and lobby views
- Tidy seat name styling and enable debug logging for name events

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c26ebac750832e95597d48530c556b