### PR TITLE
Use structured card objects across deck and dealing

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,7 +247,11 @@
       });
       return out;
     };
-    const cardText = (c) => (c ? `${c.rank || ""}${c.suit || ""}` : "");
+    const cardText = (c) => {
+      if (!c) return "";
+      if (typeof c === "string") return c;
+      return `${c.rank || ""}${c.suit || ""}`;
+    };
 
     // ---------- Auth with per-tab session ----------
     await setPersistence(auth, browserSessionPersistence);
@@ -563,7 +567,13 @@ function setupActionBar(mePlayer, room) {
             if (pid === bbPid) { commit = Math.min(stack, bbC); stack = Math.max(0, stack - bbC); }
             committed[pid] = commit;
             potC += commit;
-            tx.update(pRef, { hole: [card1, card2], stack });
+            tx.update(pRef, {
+              hole: [
+                { rank: card1.rank, suit: card1.suit },
+                { rank: card2.rank, suit: card2.suit }
+              ],
+              stack
+            });
           }
           const handId = Date.now().toString(36);
           const lock = { name: 'deal', by: dealerUid, handId, at: serverTimestamp() };

--- a/lib/deck.js
+++ b/lib/deck.js
@@ -2,9 +2,9 @@ export function fullDeck(){
   const ranks = ['2','3','4','5','6','7','8','9','T','J','Q','K','A'];
   const suits = ['s','h','d','c'];
   const deck = [];
-  for(const r of ranks){
-    for(const s of suits){
-      deck.push(r+s);
+  for (const r of ranks) {
+    for (const s of suits) {
+      deck.push({ rank: r, suit: s });
     }
   }
   return deck;


### PR DESCRIPTION
## Summary
- Generate full decks as `{rank, suit}` objects instead of concatenated strings.
- Deal and persist card objects to Firestore during `startHand`.
- Render card text safely from either string or object values.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c275563f94832eb05c4f5ee554650f