### PR TITLE
Ensure null turn and river when initializing rooms

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -155,7 +155,7 @@
               await updateDoc(doc(db, "rooms", id), {
                 phase: "idle", street: "idle", dealerId: null, potC: 0,
                 totalCommittedC: {}, bet: null,
-                board: { flop: [], turn: [], river: [] },
+                board: { flop: [], turn: null, river: null },
                 showBoard: { flop: false, turn: false, river: false },
                 lastResult: null
               });
@@ -185,7 +185,7 @@
         potC: 0,
         totalCommittedC: {},
         bet: null,
-        board: { flop: [], turn: [], river: [] },
+        board: { flop: [], turn: null, river: null },
         showBoard: { flop: false, turn: false, river: false },
         announcements: [],
         lastResult: null


### PR DESCRIPTION
## Summary
- Initialize `board.turn` and `board.river` as `null` when rooms are created or reset
- Confirmed `renderTable` uses null-aware logic for missing board streets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2755aac4c832ebd566d42bc7901ab