### PR TITLE
Add mobile boot badge overlay and logger

### DIFF
--- a/public/boot-logger.js
+++ b/public/boot-logger.js
@@ -1,0 +1,130 @@
+(function (global) {
+  if (global.__BOOT_LOGGER_INIT__) return;
+  global.__BOOT_LOGGER_INIT__ = true;
+
+  const previous = global.BootLogger || {};
+  const previousEmit = typeof previous.emit === 'function' ? previous.emit.bind(previous) : null;
+  const previousEmitError = typeof previous.emitError === 'function' ? previous.emitError.bind(previous) : null;
+  const previousRefresh = typeof previous.refreshBadge === 'function' ? previous.refreshBadge.bind(previous) : null;
+  const previousLast = typeof previous.last === 'function' ? previous.last.bind(previous) : null;
+
+  const MOBILE_UA = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|Mobi/i;
+  const BOOT_PREFIX = /^\[BOOT(?:\]\[ERR])?\]\s*/;
+  const state = {
+    last: '',
+    pending: null,
+    badge: null
+  };
+
+  const original = {
+    log: global.console && global.console.log ? global.console.log.bind(global.console) : function () {},
+    error: global.console && global.console.error ? global.console.error.bind(global.console) : function () {}
+  };
+
+  function locateBadge() {
+    if (state.badge && state.badge.isConnected) return state.badge;
+    state.badge = global.document ? global.document.getElementById('boot-badge') : null;
+    return state.badge;
+  }
+
+  function normalise(line) {
+    if (typeof line !== 'string') return '';
+    const stripped = line.replace(BOOT_PREFIX, '').trim();
+    return stripped || line.trim();
+  }
+
+  function applyBadge(text) {
+    const badge = locateBadge();
+    if (badge) {
+      badge.textContent = text;
+      badge.dataset.active = '1';
+      state.pending = null;
+    } else {
+      state.pending = text;
+    }
+  }
+
+  function handleBoot(line) {
+    const text = normalise(line) || 'Booting…';
+    state.last = text;
+    applyBadge(text);
+  }
+
+  function inspectArgs(args) {
+    for (const arg of args) {
+      if (typeof arg === 'string' && BOOT_PREFIX.test(arg)) {
+        handleBoot(arg);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function flushPending() {
+    if (state.pending) applyBadge(state.pending);
+  }
+
+  function initBadge() {
+    if (!global.document) return;
+    if (MOBILE_UA.test(global.navigator?.userAgent || '')) {
+      global.document.documentElement.classList.add('is-mobile-ua');
+    }
+    const badge = locateBadge();
+    if (badge) {
+      badge.setAttribute('role', 'status');
+      badge.setAttribute('aria-live', 'polite');
+      const initial = state.last || state.pending || 'Booting…';
+      applyBadge(initial);
+    }
+  }
+
+  const BootLogger = {
+    emit(message, ...rest) {
+      if (typeof message === 'string') inspectArgs([message]);
+      if (previousEmit) return previousEmit(message, ...rest);
+      return original.log(message, ...rest);
+    },
+    emitError(message, ...rest) {
+      if (typeof message === 'string') inspectArgs([message]);
+      if (previousEmitError) return previousEmitError(message, ...rest);
+      return original.error(message, ...rest);
+    },
+    last() {
+      if (state.last) return state.last;
+      return previousLast ? previousLast() : state.last;
+    },
+    refreshBadge() {
+      if (previousRefresh) previousRefresh();
+      if (state.last) {
+        applyBadge(state.last);
+      } else {
+        flushPending();
+      }
+    }
+  };
+
+  if (global.console) {
+    global.console.log = function (...args) {
+      inspectArgs(args);
+      return original.log(...args);
+    };
+    global.console.error = function (...args) {
+      inspectArgs(args);
+      return original.error(...args);
+    };
+  }
+
+  if (global.document) {
+    if (global.document.readyState === 'loading') {
+      global.document.addEventListener('DOMContentLoaded', () => {
+        initBadge();
+        flushPending();
+      });
+    } else {
+      initBadge();
+      flushPending();
+    }
+  }
+
+  global.BootLogger = Object.assign({}, previous, BootLogger);
+})(window);

--- a/public/index.html
+++ b/public/index.html
@@ -6,11 +6,13 @@
   <link rel="stylesheet" href="/styles.css" />
 </head>
 <body>
+  <div id="boot-badge" class="boot-badge" role="status" aria-live="polite">Booting…</div>
   <header class="lobby-header">
     <h1>Lobby</h1>
     <div id="wallet-badge">$<span id="wallet-balance">0</span></div>
   </header>
   <main id="rooms-grid" class="rooms-grid"></main>
+  <script src="/boot-logger.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.0.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.0.1/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.0.1/firebase-firestore-compat.js"></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -8,6 +8,30 @@ body{ background:var(--ink-3); color:#e9edf3; font-family:system-ui,Segoe UI,Rob
 header{ display:flex; align-items:center; gap:12px; padding:8px 16px; background:var(--ink-2); border-bottom:1px solid #2b3040; color:#e9edf3; }
 header .left{ display:flex; align-items:center; gap:8px; }
 .build-tag{ margin-left:8px; color:var(--muted); font-size:12px; }
+.boot-badge{
+  position:fixed;
+  top:12px; left:12px;
+  display:none;
+  align-items:center;
+  padding:6px 12px;
+  border-radius:999px;
+  background:rgba(7,11,24,.92);
+  color:#fff;
+  font-size:12px;
+  font-weight:600;
+  letter-spacing:.03em;
+  line-height:1.25;
+  box-shadow:0 10px 26px rgba(0,0,0,.4);
+  z-index:4000;
+  pointer-events:none;
+  max-width:82vw;
+  word-break:break-word;
+}
+.boot-badge[data-active="1"]{ opacity:1; }
+@media (max-width: 820px){
+  .boot-badge{ display:flex; }
+}
+.is-mobile-ua .boot-badge{ display:flex; }
 .layout{ display:flex; }
 .table-wrap{ display:flex; align-items:center; justify-content:center; min-height:calc(100vh - 120px); }
 .poker-table{ position:relative; width:1000px; height:640px; }

--- a/public/table.html
+++ b/public/table.html
@@ -6,6 +6,7 @@
   <link rel="stylesheet" href="/styles.css" />
 </head>
 <body>
+  <div id="boot-badge" class="boot-badge" role="status" aria-live="polite">Booting…</div>
   <header class="table-head">
     <button id="btn-leave" title="Leave room">⟵ Lobby</button>
     <div class="variant">
@@ -51,6 +52,7 @@
     </div>
   </main>
   <aside id="debug-panel"><div id="debug-log"></div></aside>
+  <script src="/boot-logger.js"></script>
   <script src="/poker-eval.js"></script>
   <script type="module" src="/app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add an absolutely-positioned boot badge container to the lobby and table pages and load the helper script before the main bundles
- style the badge for mobile viewports with a high-contrast pill design that stays hidden on larger screens
- introduce a boot logger helper that mirrors the latest `[BOOT]` status on the badge while tolerating pages without the element

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68caee3dc8b8832e8a0c2ba9f386bbe5