### PR TITLE
Add Firestore diagnostics banner and listener error handling

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -101,17 +101,34 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 const auth = getAuth(app);
 const db = getFirestore(app);
+const bootDiag = window.BootDiagnostics || null;
+const reportFsListenerError = (scope, err) => {
+  bootDiag?.reportFsListenerError?.(scope, err);
+};
+const reportFsOpError = (scope, err) => {
+  bootDiag?.reportFsOpError?.(scope, err);
+};
+const clearFsError = () => {
+  bootDiag?.clearFsError?.();
+};
+bootDiag?.setStage?.('table:init');
 let walletBalance = 0;
 
 async function ensureWallet(uid){
   const wRef = doc(db,'wallets',uid);
-  const snap = await getDoc(wRef);
-  if(!snap.exists()){
-    await setDoc(wRef,{ balance:100, createdAt:serverTimestamp(), updatedAt:serverTimestamp() });
-    walletBalance = 100;
-    debug.log('wallet.init',{ balance:100 });
-  }else{
-    walletBalance = snap.data().balance || 0;
+  try {
+    const snap = await getDoc(wRef);
+    if(!snap.exists()){
+      await setDoc(wRef,{ balance:100, createdAt:serverTimestamp(), updatedAt:serverTimestamp() });
+      walletBalance = 100;
+      debug.log('wallet.init',{ balance:100 });
+    }else{
+      walletBalance = snap.data().balance || 0;
+    }
+    clearFsError();
+  } catch (err) {
+    reportFsOpError('table.ensureWallet', err);
+    throw err;
   }
 }
 
@@ -119,32 +136,38 @@ async function ensureWallet(uid){
 async function ensureRoomDisplayName(db, roomRef, uid) {
   const rx = /^Player(\d+)$/;
   let assigned = null;
-  await runTransaction(db, async (tx) => {
-    const snap = await tx.get(roomRef);
-    if (!snap.exists()) throw new Error('Room missing');
-    const room = snap.data() || {};
-    const players = room.players || {};
+  try {
+    await runTransaction(db, async (tx) => {
+      const snap = await tx.get(roomRef);
+      if (!snap.exists()) throw new Error('Room missing');
+      const room = snap.data() || {};
+      const players = room.players || {};
 
-    const mine = players[uid] || {};
-    if (mine.displayName && rx.test(mine.displayName)) {
-      assigned = mine.displayName;
-      return;
-    }
-
-    const used = new Set();
-    Object.values(players).forEach(p => {
-      if (p && typeof p.displayName === 'string') {
-        const m = p.displayName.match(rx);
-        if (m) used.add(parseInt(m[1], 10));
+      const mine = players[uid] || {};
+      if (mine.displayName && rx.test(mine.displayName)) {
+        assigned = mine.displayName;
+        return;
       }
-    });
 
-    let n = 1;
-    while (used.has(n)) n++;
-    assigned = `Player${n}`;
-    const path = `players.${uid}.displayName`;
-    tx.update(roomRef, { [path]: assigned });
-  });
+      const used = new Set();
+      Object.values(players).forEach(p => {
+        if (p && typeof p.displayName === 'string') {
+          const m = p.displayName.match(rx);
+          if (m) used.add(parseInt(m[1], 10));
+        }
+      });
+
+      let n = 1;
+      while (used.has(n)) n++;
+      assigned = `Player${n}`;
+      const path = `players.${uid}.displayName`;
+      tx.update(roomRef, { [path]: assigned });
+    });
+    clearFsError();
+  } catch (err) {
+    reportFsOpError('table.ensureRoomDisplayName', err);
+    throw err;
+  }
 
   window.DEBUG?.log('name.assign.success', { displayName: assigned });
   return assigned;
@@ -161,9 +184,17 @@ onAuthStateChanged(auth, async (user) => {
   const playerSpan = document.getElementById('player-id');
   if (playerSpan) playerSpan.textContent = user.uid;
 
-  await ensureWallet(user.uid);
+  try {
+    await ensureWallet(user.uid);
+  } catch (err) {
+    return;
+  }
+
   if (initialRoom) {
-    await joinRoomByCode(initialRoom.toUpperCase());
+    try {
+      await joinRoomByCode(initialRoom.toUpperCase());
+    } catch (err) {
+    }
   }
   window.DEBUG?.log('firebase.init.ok', { appName: app.name });
   window.DEBUG?.log('auth.anon.signIn.success', { uid: user.uid, persistence: 'session' });
@@ -180,7 +211,9 @@ onAuthStateChanged(auth, async (user) => {
     leaveBtn.onclick = async () => {
       try {
         await safeUnseatAndCreditIfIdle();
-      } catch(_) {}
+      } catch(err) {
+        if (err?.code) reportFsOpError('table.leave.safeUnseat', err);
+      }
       debug.log('nav.table.leave', { roomCode });
       location.href = '/';
     };
@@ -590,6 +623,8 @@ async function sweepExpiredDealLock(db, roomRef) {
   } catch (e) {
     if (e.code === 'RELEASED') {
       window.DEBUG?.log('hand.lock.sweeper.release.success', {});
+    } else if (e?.code) {
+      reportFsOpError('table.sweepDealLock', e);
     }
   }
 
@@ -738,6 +773,7 @@ if (prefEl) {
       window.DEBUG?.log('variant.pref.set', { pid, value: val });
     } catch (err) {
       window.DEBUG?.log('variant.pref.error', { message: String(err) });
+      reportFsOpError('table.variantPref.update', err);
     }
   };
 }
@@ -808,6 +844,7 @@ if (nextStreetBtn) {
       }
     } catch (e) {
       window.DEBUG?.log('street.advance.tx.error', { code: e.code || 'UNKNOWN', detail: e });
+      if (e?.code) reportFsOpError('table.street.advance', e);
     }
   });
 }
@@ -945,6 +982,7 @@ if (settleBtn) {
       }
     } catch (e) {
       window.DEBUG?.log('settle.tx.error', { code: e.code || 'UNKNOWN', detail: e });
+      if (e?.code) reportFsOpError('table.settle', e);
     }
   });
 }
@@ -986,32 +1024,36 @@ async function onActionCommitted(roomRef){
   });
 }
 async function maybeAdvanceStreetAsDealer(roomRef, uid){
-  await runTransaction(db, async tx => {
-    const snap = await tx.get(roomRef); const room = snap.data(); if (!room?.hand) return;
-    if (room.hand.dealerPid !== uid) return; const b = room.hand.betting;
-    if (!b?.roundClosed) return;
-    const status = room.hand.status;
-    const deckSeed = room.code + room.hand.id;
-    const deck = shuffledDeck(deckSeed);
-    let append = [];
-    if (status === 'preflop') append = deck.slice(0,3);
-    else if (status === 'flop') append = deck.slice(3,4);
-    else if (status === 'turn') append = deck.slice(4,5);
-    else if (status === 'river') return;
-    const nextStatus = status === 'preflop' ? 'flop' : status === 'flop' ? 'turn' : 'river';
-    tx.update(roomRef, {
-      'hand.board': (room.hand.board || []).concat(append),
-      'hand.status': nextStatus,
-      'hand.betting.currentBet': 0,
-      'hand.betting.lastRaiseSize': b.bb,
-      'hand.betting.minRaiseTo': b.bb,
-      'hand.betting.committed': Object.fromEntries(Object.keys(b.committed || {}).map(pid => [pid,0])),
-      'hand.betting.roundClosed': false,
-      'hand.turn.index': 0,
-      'hand.turn.untilPid': null
+  try {
+    await runTransaction(db, async tx => {
+      const snap = await tx.get(roomRef); const room = snap.data(); if (!room?.hand) return;
+      if (room.hand.dealerPid !== uid) return; const b = room.hand.betting;
+      if (!b?.roundClosed) return;
+      const status = room.hand.status;
+      const deckSeed = room.code + room.hand.id;
+      const deck = shuffledDeck(deckSeed);
+      let append = [];
+      if (status === 'preflop') append = deck.slice(0,3);
+      else if (status === 'flop') append = deck.slice(3,4);
+      else if (status === 'turn') append = deck.slice(4,5);
+      else if (status === 'river') return;
+      const nextStatus = status === 'preflop' ? 'flop' : status === 'flop' ? 'turn' : 'river';
+      tx.update(roomRef, {
+        'hand.board': (room.hand.board || []).concat(append),
+        'hand.status': nextStatus,
+        'hand.betting.currentBet': 0,
+        'hand.betting.lastRaiseSize': b.bb,
+        'hand.betting.minRaiseTo': b.bb,
+        'hand.betting.committed': Object.fromEntries(Object.keys(b.committed || {}).map(pid => [pid,0])),
+        'hand.betting.roundClosed': false,
+        'hand.turn.index': 0,
+        'hand.turn.untilPid': null
+      });
+      window.DEBUG?.log('street.advance.tx.success', { status: nextStatus, appended: append.length });
     });
-    window.DEBUG?.log('street.advance.tx.success', { status: nextStatus, appended: append.length });
-  });
+  } catch (e) {
+    if (e?.code) reportFsOpError('table.maybeAdvanceStreet', e);
+  }
 }
 if (foldBtn) {
   foldBtn.addEventListener('click', async () => {
@@ -1045,6 +1087,7 @@ if (foldBtn) {
       window.DEBUG?.log('action.fold.success', { pid: uid });
     } catch (e) {
       window.DEBUG?.log('action.fold.error', { code: e.code || 'UNKNOWN' });
+      if (e?.code) reportFsOpError('table.action.fold', e);
     }
     renderActionControls(currentRoom);
   });
@@ -1106,6 +1149,7 @@ if (foldBtn) {
       await onActionCommitted(currentRoomRef);
     } catch (e) {
       window.DEBUG?.log('action.check.error', { code: e.code || 'UNKNOWN' });
+      if (e?.code) reportFsOpError('table.action.call', e);
     }
     renderActionControls(currentRoom);
   });
@@ -1116,7 +1160,7 @@ if (foldBtn) {
     const uid = auth.currentUser?.uid;
     const desired = parseInt(betInput?.value || '0', 10);
     try {
-      await runTransaction(db, async (tx) => {
+      const txRes = await runTransaction(db, async (tx) => {
         const snap = await tx.get(currentRoomRef);
         if (!snap.exists()) throw { code: 'ROOM_MISSING' };
         const room = snap.data();
@@ -1163,6 +1207,7 @@ if (foldBtn) {
       await onActionCommitted(currentRoomRef);
     } catch (e) {
       window.DEBUG?.log('action.bet.error', { code: e.code || 'UNKNOWN' });
+      if (e?.code) reportFsOpError('table.action.raise', e);
     }
     renderActionControls(currentRoom);
   });
@@ -1374,52 +1419,62 @@ async function joinRoomByCode(code){
   const uid = auth.currentUser?.uid;
   if(!uid) return;
   const roomRef = doc(db,'rooms',code);
-  const seat = await runTransaction(db, async (tx) => {
-    const snap = await tx.get(roomRef);
-    if(!snap.exists()) throw { code:'ROOM_MISSING' };
-    const data = snap.data() || {};
-    const pathBase = `players.${uid}`;
-    const player = data.players?.[uid] || {};
-    if (!data.players || !data.players[uid]) {
-      tx.update(roomRef, {
-        [`${pathBase}.seat`]: null,
-        [`${pathBase}.lastSeen`]: serverTimestamp(),
-        [`${pathBase}.joinedAt`]: serverTimestamp(),
-        [`${pathBase}.active`]: true
-      });
-    } else {
-      tx.update(roomRef, {
-        [`${pathBase}.lastSeen`]: serverTimestamp(),
-        [`${pathBase}.active`]: true
-      });
-    }
-    return player.seat ?? null;
-  });
+  try {
+    const seat = await runTransaction(db, async (tx) => {
+      const snap = await tx.get(roomRef);
+      if(!snap.exists()) throw { code:'ROOM_MISSING' };
+      const data = snap.data() || {};
+      const pathBase = `players.${uid}`;
+      const player = data.players?.[uid] || {};
+      if (!data.players || !data.players[uid]) {
+        tx.update(roomRef, {
+          [`${pathBase}.seat`]: null,
+          [`${pathBase}.lastSeen`]: serverTimestamp(),
+          [`${pathBase}.joinedAt`]: serverTimestamp(),
+          [`${pathBase}.active`]: true
+        });
+      } else {
+        tx.update(roomRef, {
+          [`${pathBase}.lastSeen`]: serverTimestamp(),
+          [`${pathBase}.active`]: true
+        });
+      }
+      return player.seat ?? null;
+    });
 
-  roomCode = code;
-  window.APP = window.APP || {};
-  window.APP.roomCode = code;
-  const myName = await ensureRoomDisplayName(db, roomRef, uid);
-  document.documentElement.setAttribute('data-me-name', myName);
-  sessionStorage.setItem('playerName', myName);
-  renderMyConsole(myName);
-  debug.log('nav.table.enter', { roomCode: code });
-  document.getElementById('room-code').textContent = code;
-  currentRoomRef = roomRef;
-  startHeartbeat(currentRoomRef, uid);
-  startEvictionSweeper(currentRoomRef, uid);
-  clearInterval(dealLockSweeperTimer);
-  dealLockSweeperTimer = setInterval(() => sweepExpiredDealLock(db, currentRoomRef), DEAL_LOCK.SWEEP_INTERVAL_MS);
-  if (roomUnsub) roomUnsub();
-  roomUnsub = onSnapshot(currentRoomRef, (snap) => {
-    const data = snap.data();
-    renderRoom(data);
-    const playersCount = data.players ? Object.keys(data.players).length : 0;
-    const seatedCount = data.seats ? data.seats.filter(Boolean).length : 0;
-    debug.log('room.snapshot', { players: playersCount, seated: seatedCount });
-    if (data?.hand?.betting?.roundClosed) { maybeAdvanceStreetAsDealer(currentRoomRef, auth.currentUser?.uid); }
-  });
-  debug.log('room.join.success', { code, seat, displayName: myName });
+    roomCode = code;
+    window.APP = window.APP || {};
+    window.APP.roomCode = code;
+    bootDiag?.setStage?.(`table:${code}`);
+    const myName = await ensureRoomDisplayName(db, roomRef, uid);
+    document.documentElement.setAttribute('data-me-name', myName);
+    sessionStorage.setItem('playerName', myName);
+    renderMyConsole(myName);
+    debug.log('nav.table.enter', { roomCode: code });
+    document.getElementById('room-code').textContent = code;
+    currentRoomRef = roomRef;
+    startHeartbeat(currentRoomRef, uid);
+    startEvictionSweeper(currentRoomRef, uid);
+    clearInterval(dealLockSweeperTimer);
+    dealLockSweeperTimer = setInterval(() => sweepExpiredDealLock(db, currentRoomRef), DEAL_LOCK.SWEEP_INTERVAL_MS);
+    if (roomUnsub) roomUnsub();
+    roomUnsub = onSnapshot(currentRoomRef, (snap) => {
+      clearFsError();
+      const data = snap.data();
+      renderRoom(data);
+      const playersCount = data.players ? Object.keys(data.players).length : 0;
+      const seatedCount = data.seats ? data.seats.filter(Boolean).length : 0;
+      debug.log('room.snapshot', { players: playersCount, seated: seatedCount });
+      if (data?.hand?.betting?.roundClosed) { maybeAdvanceStreetAsDealer(currentRoomRef, auth.currentUser?.uid); }
+    }, (err) => {
+      reportFsListenerError('table.room', err);
+    });
+    debug.log('room.join.success', { code, seat, displayName: myName });
+    clearFsError();
+  } catch (err) {
+    reportFsOpError('table.joinRoom', err);
+    throw err;
+  }
 }
 
 async function submitJoin(mode) {
@@ -1515,6 +1570,7 @@ async function submitJoin(mode) {
     roomCode = code;
     window.APP = window.APP || {};
     window.APP.roomCode = code;
+    bootDiag?.setStage?.(`table:${code}`);
     document.getElementById('room-code').textContent = code;
     debug.log('room.join.success', { code, seat });
     if (created) {
@@ -1536,13 +1592,17 @@ async function submitJoin(mode) {
 
     if (roomUnsub) roomUnsub();
     roomUnsub = onSnapshot(roomRef, (snap) => {
+      clearFsError();
       const data = snap.data();
       renderRoom(data);
       const playersCount = data.players ? Object.keys(data.players).length : 0;
       const seatedCount = data.seats ? data.seats.filter(Boolean).length : 0;
       debug.log('room.snapshot', { players: playersCount, seated: seatedCount });
       if (data?.hand?.betting?.roundClosed) { maybeAdvanceStreetAsDealer(currentRoomRef, auth.currentUser?.uid); }
+    }, (err) => {
+      reportFsListenerError('table.room', err);
     });
+    clearFsError();
   } catch (err) {
     if (err.message === 'ROOM_FULL') {
       joinError.textContent = 'Room is full.';
@@ -1550,6 +1610,9 @@ async function submitJoin(mode) {
     } else {
       joinError.textContent = 'Failed to join room.';
       debug.log('room.join.error', { code, reason: 'UNKNOWN' });
+    }
+    if (err?.code) {
+      reportFsOpError('table.submitJoin', err);
     }
   }
 }
@@ -1585,7 +1648,7 @@ async function maybeInitTurn(room) {
     });
     window.DEBUG?.log('turn.init', { street: hand.status, orderLen: order.length });
   } catch (e) {
-    // ignore
+    if (e?.code) reportFsOpError('table.maybeInitTurn', e);
   }
 }
 
@@ -1668,6 +1731,7 @@ async function maybeInitBetting(room) {
     }
   } catch (e) {
     window.DEBUG?.log('betting.init.error', { code: e.code || 'UNKNOWN' });
+    if (e?.code) reportFsOpError('table.maybeInitBetting', e);
   }
 }
 
@@ -1897,6 +1961,7 @@ function ensureMyHandListener(room) {
   myHandId = handId;
   const handRef = doc(db, 'rooms', roomCode, 'players', uid, 'hands', handId);
   myHandUnsub = onSnapshot(handRef, (snap) => {
+    clearFsError();
     if (snap.exists()) {
       const data = snap.data();
       myHandCards = data.cards || [];
@@ -1905,6 +1970,8 @@ function ensureMyHandListener(room) {
       window.DEBUG?.log('ui.hole.render.mine', { cards: myHandCards });
       renderRoom(currentRoom);
     }
+  }, (err) => {
+    reportFsListenerError('table.hand', err);
   });
 }
 
@@ -1916,7 +1983,7 @@ async function ensureRoomConfig(room) {
       await updateDoc(currentRoomRef, { config: DEFAULT_CONFIG });
     }
   } catch (e) {
-    // ignore
+    if (e?.code) reportFsOpError('table.ensureRoomConfig', e);
   }
   room.config = { ...DEFAULT_CONFIG };
 }
@@ -1924,26 +1991,30 @@ async function ensureRoomConfig(room) {
 async function safeUnseatAndCreditIfIdle(){
   const uid = auth.currentUser?.uid;
   if(!uid || !currentRoomRef) return;
-  await runTransaction(db, async tx => {
-    const snap = await tx.get(currentRoomRef);
-    if(!snap.exists()) return;
-    const room = snap.data();
-    if(room.state !== 'idle') return;
-    const seat = room.players?.[uid]?.seat;
-    if(seat == null) return;
-    const seats = room.seats || [];
-    const stackMap = room.stacks || {};
-    const players = room.players || {};
-    const stack = stackMap[uid] || 0;
-    const wRef = doc(db,'wallets',uid);
-    const wSnap = await tx.get(wRef);
-    const bal = wSnap.data()?.balance || 0;
-    seats[seat] = null;
-    players[uid].seat = null;
-    delete stackMap[uid];
-    tx.update(wRef,{ balance: bal + stack });
-    tx.update(currentRoomRef,{ seats, players, stacks: stackMap });
-  });
+  try {
+    await runTransaction(db, async tx => {
+      const snap = await tx.get(currentRoomRef);
+      if(!snap.exists()) return;
+      const room = snap.data();
+      if(room.state !== 'idle') return;
+      const seat = room.players?.[uid]?.seat;
+      if(seat == null) return;
+      const seats = room.seats || [];
+      const stackMap = room.stacks || {};
+      const players = room.players || {};
+      const stack = stackMap[uid] || 0;
+      const wRef = doc(db,'wallets',uid);
+      const wSnap = await tx.get(wRef);
+      const bal = wSnap.data()?.balance || 0;
+      seats[seat] = null;
+      players[uid].seat = null;
+      delete stackMap[uid];
+      tx.update(wRef,{ balance: bal + stack });
+      tx.update(currentRoomRef,{ seats, players, stacks: stackMap });
+    });
+  } catch (e) {
+    if (e?.code) reportFsOpError('table.safeUnseat', e);
+  }
 }
 
 async function maybeLockNextVariant(room, gate) {
@@ -1974,7 +2045,7 @@ async function maybeLockNextVariant(room, gate) {
       window.DEBUG?.log('variant.lock.next', { value: res.value, dealerPid: res.dealerPid });
     }
   } catch (e) {
-    // ignore
+    if (e?.code) reportFsOpError('table.maybeLockNextVariant', e);
   }
 }
 
@@ -1997,6 +2068,7 @@ async function maybeAutoDeal(room, gate) {
     }
   } catch (e) {
     window.DEBUG?.log('hand.lock.tx.error', { code: e.code || 'UNKNOWN', detail: e });
+    if (e?.code) reportFsOpError('table.maybeAutoDeal', e);
   }
 }
 
@@ -2117,5 +2189,6 @@ async function runDealFlow(room) {
     window.DEBUG?.log('hand.deal.commit.success', { handId: hand.id });
   } catch (e) {
     window.DEBUG?.log('hand.deal.error', { code: e.code || 'UNKNOWN' });
+    if (e?.code) reportFsOpError('table.runDealFlow', e);
   }
 }

--- a/public/diagnostics.js
+++ b/public/diagnostics.js
@@ -1,0 +1,96 @@
+(function(global) {
+  const state = {
+    stageText: '',
+    errorText: null,
+    bannerId: 'fs-error-banner',
+    badgeId: 'boot-overlay-badge'
+  };
+
+  function getBannerEl() {
+    return global.document?.getElementById(state.bannerId) || null;
+  }
+
+  function getBadgeEl() {
+    return global.document?.getElementById(state.badgeId) || null;
+  }
+
+  function updateBadge(text) {
+    const badge = getBadgeEl();
+    if (!badge) return;
+    if (text) {
+      badge.textContent = text;
+      badge.classList.remove('hidden');
+    } else {
+      badge.textContent = '';
+      badge.classList.add('hidden');
+    }
+  }
+
+  function setStage(text) {
+    state.stageText = text || '';
+    if (!state.errorText) {
+      updateBadge(state.stageText);
+    }
+  }
+
+  function showBanner(message) {
+    const banner = getBannerEl();
+    if (!banner) return;
+    banner.textContent = message;
+    banner.classList.remove('hidden');
+    state.errorText = message;
+    updateBadge(message);
+  }
+
+  function clearBanner() {
+    const banner = getBannerEl();
+    if (!banner) return;
+    banner.textContent = '';
+    banner.classList.add('hidden');
+    state.errorText = null;
+    updateBadge(state.stageText);
+  }
+
+  function extractErrorDetails(err) {
+    if (!err) {
+      return { code: 'unknown', message: 'Unknown error' };
+    }
+    const code = typeof err.code === 'string' ? err.code : (typeof err.name === 'string' ? err.name : 'unknown');
+    const message = typeof err.message === 'string' ? err.message : String(err);
+    return { code, message };
+  }
+
+  function reportError(tag, scope, err) {
+    const { code, message } = extractErrorDetails(err);
+    const parts = [`[BOOT][ERR] tag=${tag}`];
+    if (scope) parts.push(`scope=${scope}`);
+    if (code) parts.push(`code=${code}`);
+    if (message) parts.push(`message=${message}`);
+    const text = parts.join(' ');
+    console.error(text);
+    if (code === 'permission-denied') {
+      showBanner(`${code}: ${message}`);
+    }
+    return { text, code, message };
+  }
+
+  const api = {
+    setStage,
+    clearFsError: clearBanner,
+    setBootBadge(text) {
+      state.stageText = text || state.stageText;
+      if (!state.errorText) updateBadge(text);
+    },
+    reportFsListenerError(scope, err) {
+      return reportError('fs-listener', scope, err);
+    },
+    reportFsOpError(scope, err) {
+      return reportError('fs-op', scope, err);
+    },
+    showFsErrorBanner(message) {
+      showBanner(message);
+    }
+  };
+
+  global.BootDiagnostics = Object.assign(global.BootDiagnostics || {}, api);
+})(window);

--- a/public/index.html
+++ b/public/index.html
@@ -6,11 +6,14 @@
   <link rel="stylesheet" href="/styles.css" />
 </head>
 <body>
+  <div id="fs-error-banner" class="fs-error-banner hidden" role="alert" aria-live="assertive"></div>
+  <div id="boot-overlay-badge" class="boot-overlay-badge hidden" aria-live="polite"></div>
   <header class="lobby-header">
     <h1>Lobby</h1>
     <div id="wallet-badge">$<span id="wallet-balance">0</span></div>
   </header>
   <main id="rooms-grid" class="rooms-grid"></main>
+  <script src="/diagnostics.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.0.1/firebase-app-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.0.1/firebase-auth-compat.js"></script>
   <script src="https://www.gstatic.com/firebasejs/11.0.1/firebase-firestore-compat.js"></script>

--- a/public/lobby.js
+++ b/public/lobby.js
@@ -1,35 +1,51 @@
 const db = firebase.firestore(), auth = firebase.auth();
+const bootDiag = window.BootDiagnostics || null;
+bootDiag?.setStage?.('lobby:init');
 const qs = new URLSearchParams(location.search); const rc = qs.get('room');
 if (rc) location.replace(`/table.html?room=${encodeURIComponent(rc)}`);
 auth.signInAnonymously().then(async () => {
-  const uid = auth.currentUser.uid;
-  const wref = db.collection('wallets').doc(uid);
-  const w = await wref.get();
-  if (!w.exists) {
-    await wref.set({
-      balance: 100,
-      createdAt: firebase.firestore.FieldValue.serverTimestamp(),
-      updatedAt: firebase.firestore.FieldValue.serverTimestamp()
-    });
-  }
-  const balSnap = await wref.get();
-  document.getElementById('wallet-balance').textContent = balSnap.data().balance.toFixed(2);
+  try {
+    const uid = auth.currentUser.uid;
+    const wref = db.collection('wallets').doc(uid);
+    const w = await wref.get();
+    if (!w.exists) {
+      await wref.set({
+        balance: 100,
+        createdAt: firebase.firestore.FieldValue.serverTimestamp(),
+        updatedAt: firebase.firestore.FieldValue.serverTimestamp()
+      });
+    }
+    const balSnap = await wref.get();
+    document.getElementById('wallet-balance').textContent = balSnap.data().balance.toFixed(2);
+    bootDiag?.setStage?.('lobby:ready');
+    bootDiag?.clearFsError?.();
 
-  const q = db.collection('rooms').orderBy('createdAt', 'desc');
-  q.onSnapshot(snap => {
-    const grid = document.getElementById('rooms-grid'); grid.innerHTML = '';
-    snap.forEach(d => {
-      const r = d.data(); const seatsUsed = (r.seats || []).filter(Boolean).length;
-      const cfg = r.config || {}, min = cfg.minBuyIn ?? 10, max = cfg.maxBuyIn ?? 20, sb = cfg.sb ?? 0.25, bb = cfg.bb ?? 0.50;
-      const div = document.createElement('div'); div.className = 'room-card';
-      div.innerHTML = `
-        <div class="room-row"><strong>${r.code}</strong><span>${seatsUsed}/9</span></div>
-        <div class="room-row">$${min}–$${max} • SB $${sb} / BB $${bb}</div>
-        <div class="room-row">Status: ${r.state || 'idle'}</div>
-        <button class="join-btn" data-code="${r.code}">Join</button>`;
-      grid.appendChild(div);
+    const q = db.collection('rooms').orderBy('createdAt', 'desc');
+    q.onSnapshot(snap => {
+      bootDiag?.clearFsError?.();
+      const grid = document.getElementById('rooms-grid'); grid.innerHTML = '';
+      snap.forEach(d => {
+        const r = d.data(); const seatsUsed = (r.seats || []).filter(Boolean).length;
+        const cfg = r.config || {}, min = cfg.minBuyIn ?? 10, max = cfg.maxBuyIn ?? 20, sb = cfg.sb ?? 0.25, bb = cfg.bb ?? 0.50;
+        const div = document.createElement('div'); div.className = 'room-card';
+        div.innerHTML = `
+          <div class="room-row"><strong>${r.code}</strong><span>${seatsUsed}/9</span></div>
+          <div class="room-row">$${min}–$${max} • SB $${sb} / BB $${bb}</div>
+          <div class="room-row">Status: ${r.state || 'idle'}</div>
+          <button class="join-btn" data-code="${r.code}">Join</button>`;
+        grid.appendChild(div);
+      });
+      grid.querySelectorAll('.join-btn').forEach(b => b.onclick = () => location.href = `/table.html?room=${encodeURIComponent(b.dataset.code)}`);
+      window.DEBUG?.log('lobby.rooms.render', { ts: new Date().toISOString(), count: snap.size });
+    }, err => {
+      bootDiag?.reportFsListenerError?.('lobby.rooms', err);
     });
-    grid.querySelectorAll('.join-btn').forEach(b => b.onclick = () => location.href = `/table.html?room=${encodeURIComponent(b.dataset.code)}`);
-    window.DEBUG?.log('lobby.rooms.render', { ts: new Date().toISOString(), count: snap.size });
-  });
+    bootDiag?.clearFsError?.();
+  } catch (err) {
+    if (err?.code) {
+      bootDiag?.reportFsOpError?.('lobby.init', err);
+    }
+  }
+}).catch(err => {
+  bootDiag?.reportFsOpError?.('lobby.auth.signIn', err);
 });

--- a/public/styles.css
+++ b/public/styles.css
@@ -5,6 +5,10 @@
   --muted:#9aa0a6; --ok:#25d366; --warn:#f5a623; --danger:#ff4d4f;
 }
 body{ background:var(--ink-3); color:#e9edf3; font-family:system-ui,Segoe UI,Roboto,Helvetica,Arial,sans-serif; margin:0; }
+.fs-error-banner{ position:fixed; top:0; left:0; right:0; padding:10px 16px; background:rgba(179,14,42,.95); color:#fff; font-weight:600; text-align:center; z-index:2000; box-shadow:0 4px 12px rgba(0,0,0,.4); }
+.fs-error-banner.hidden{ display:none; }
+.boot-overlay-badge{ position:fixed; bottom:16px; right:16px; background:rgba(23,25,36,.92); color:#fff; padding:8px 12px; border-radius:12px; font-size:12px; line-height:1.4; max-width:260px; box-shadow:0 8px 20px rgba(0,0,0,.5); z-index:1900; }
+.boot-overlay-badge.hidden{ display:none; }
 header{ display:flex; align-items:center; gap:12px; padding:8px 16px; background:var(--ink-2); border-bottom:1px solid #2b3040; color:#e9edf3; }
 header .left{ display:flex; align-items:center; gap:8px; }
 .build-tag{ margin-left:8px; color:var(--muted); font-size:12px; }

--- a/public/table.html
+++ b/public/table.html
@@ -6,6 +6,8 @@
   <link rel="stylesheet" href="/styles.css" />
 </head>
 <body>
+  <div id="fs-error-banner" class="fs-error-banner hidden" role="alert" aria-live="assertive"></div>
+  <div id="boot-overlay-badge" class="boot-overlay-badge hidden" aria-live="polite"></div>
   <header class="table-head">
     <button id="btn-leave" title="Leave room">⟵ Lobby</button>
     <div class="variant">
@@ -51,6 +53,7 @@
     </div>
   </main>
   <aside id="debug-panel"><div id="debug-log"></div></aside>
+  <script src="/diagnostics.js"></script>
   <script src="/poker-eval.js"></script>
   <script type="module" src="/app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- add a shared diagnostics helper and DOM elements to surface permission-denied errors across the lobby and table views
- wrap Firestore transactions and listeners in guards that log `[BOOT][ERR]` messages, drive the overlay badge, and clear banners on recovery
- ensure critical game actions and lobby flows report Firestore errors consistently for easier troubleshooting

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68caee50fde4832ea48056a4f5170caa